### PR TITLE
[FEAT] 회원 별 취미 나머지 취미 id 리스트 조회 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -14,31 +14,34 @@ public enum ErrorStatus implements BaseErrorCode {
 	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
 
 	// 회원 별 취미 데이터가 존재하지 않음
-	GET_USER_HOBBIES_NOT_FOUND(HttpStatus.NOT_FOUND, "HOBBIES401",
-		"해당 회원의 취미 리스트가 존재하지 않습니다. 취미 조사 후 이용해주세요."),
+	GET_USER_HOBBIES_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_HOBBIES401",
+			"해당 회원의 취미 리스트가 존재하지 않습니다. 취미 조사 후 이용해주세요."),
+	// 회원 별 취미 데이터가 10개 미만
+	GET_USER_HOBBIES_LESS(HttpStatus.NOT_FOUND, "USER_HOBBIES402",
+			"회원 별 취미 데이터가 10개 미만입니다. 해당 회원의 취미를 더 추가해주세요."),
 
 	// 취미 데이터가 존재하지 않음
 	GET_HOBBY_NOT_FOUND(HttpStatus.NOT_FOUND, "HOBBY401",
-		"해당 취미가 존재하지 않습니다. 취미를 다시 확인해주세요."),
+			"해당 취미가 존재하지 않습니다. 취미를 다시 확인해주세요."),
 	// 취미 데이터가 10개 미만
 	GET_HOBBY_SIZE_LESS(HttpStatus.NOT_FOUND, "HOBBY402",
-		"취미 데이터가 10개 미만입니다. 취미를 더 추가해주세요."),
+			"취미 데이터가 10개 미만입니다. 취미를 더 추가해주세요."),
 	// 취미 데이터가 다 삭제되지 않음
 	DELETE_HOBBY_NOT_ALL(HttpStatus.NOT_FOUND, "HOBBY403",
-		"취미 데이터가 모두 삭제되지 않았습니다. 다시 시도해주세요."),
+			"취미 데이터가 모두 삭제되지 않았습니다. 다시 시도해주세요."),
 
 	// 취미 추천 설문 질문 리스트가 비어있음
 	GET_HOBBY_SURVEY_QUESTIONS_EMPTY(HttpStatus.NOT_FOUND, "SURVEY401",
-		"취미 추천 설문 질문 리스트가 비어있습니다."),
+			"취미 추천 설문 질문 리스트가 비어있습니다."),
 	// 취미 추천 설문 질문 리스트가 20개 미만
 	GET_HOBBY_SURVEY_QUESTIONS_LESS(HttpStatus.NOT_FOUND, "SURVEY402",
-		"취미 추천 설문 질문 리스트가 20개 미만입니다. 취미 추천 더 질문을 등록해주세요."),
+			"취미 추천 설문 질문 리스트가 20개 미만입니다. 취미 추천 더 질문을 등록해주세요."),
 	// 취미 추천 설문 응답 리스트가 비어있음
 	HOBBY_SURVEY_QUESTIONS_EMPTY(HttpStatus.BAD_REQUEST, "SURVEY403",
-		"취미 추천 설문 응답 리스트가 비어있습니다."),
+			"취미 추천 설문 응답 리스트가 비어있습니다."),
 	// 취미 추천 설문 응답 리스트가 20개 미만이거나 초과
 	HOBBY_SURVEY_QUESTIONS_SIZE_LESS_OR_OVER(HttpStatus.BAD_REQUEST, "SURVEY405",
-		"취미 추천 설문 응답 리스트가 20개 미만이거나 20개를 초과했습니다. 취미 추천 설문 응답을 20개로 맞춰주세요.");
+			"취미 추천 설문 응답 리스트가 20개 미만이거나 20개를 초과했습니다. 취미 추천 설문 응답을 20개로 맞춰주세요.");
 
 	private final HttpStatus httpStatus;
 	private final String status;
@@ -55,19 +58,19 @@ public enum ErrorStatus implements BaseErrorCode {
 	@Override
 	public ErrorReasonDto getReason() {
 		return ErrorReasonDto
-			.builder()
-			.code(status)
-			.message(message)
-			.build();
+				.builder()
+				.code(status)
+				.message(message)
+				.build();
 	}
 
 	@Override
 	public ErrorReasonDto getReasonHttpStatus() {
 		return ErrorReasonDto
-			.builder()
-			.httpStatus(httpStatus)
-			.code(status)
-			.message(message)
-			.build();
+				.builder()
+				.httpStatus(httpStatus)
+				.code(status)
+				.message(message)
+				.build();
 	}
 }

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -14,6 +14,8 @@ public enum SuccessStatus implements BaseCode {
 
 	// 회원 별 취미 조회 성공
 	GET_USER_HOBBIES_SUCCESS(HttpStatus.OK, "200", "해당 회원의 취미 리스트 조회를 성공하였습니다."),
+	// 나머지 회원 취미 추천 조회 성공
+	GET_REMAINING_USER_HOBBIES_SUCCESS(HttpStatus.OK, "200", "해당 회원의 나머지 취미 추천 리스트 조회를 성공하였습니다."),
 	// 회원 별 취미 카드 리스트 조회 성공
 	GET_USER_HOBBY_CARDS_SUCCESS(HttpStatus.OK, "200", "해당 회원의 취미 카드 리스트 조회를 성공하였습니다."),
 
@@ -38,19 +40,19 @@ public enum SuccessStatus implements BaseCode {
 	@Override
 	public ReasonDto getReason() {
 		return ReasonDto
-			.builder()
-			.code(status)
-			.message(message)
-			.build();
+				.builder()
+				.code(status)
+				.message(message)
+				.build();
 	}
 
 	@Override
 	public ReasonDto getReasonHttpStatus() {
 		return ReasonDto
-			.builder()
-			.httpStatus(httpStatus)
-			.code(status)
-			.message(message)
-			.build();
+				.builder()
+				.httpStatus(httpStatus)
+				.code(status)
+				.message(message)
+				.build();
 	}
 }

--- a/src/main/java/hobbiedo/survey/application/HobbyServiceImpl.java
+++ b/src/main/java/hobbiedo/survey/application/HobbyServiceImpl.java
@@ -27,12 +27,17 @@ public class HobbyServiceImpl implements HobbyService {
 	public List<UserHobbyResponseDto> getUserHobbies(String uuid) {
 
 		List<UserHobby> userHobbies = Optional.ofNullable(userHobbyRepository.findByUuid(uuid))
-			.filter(list -> !list.isEmpty())
-			.orElseThrow(() -> new SurveyExceptionHandler(GET_USER_HOBBIES_NOT_FOUND));
+				.filter(list -> !list.isEmpty())
+				.orElseThrow(() -> new SurveyExceptionHandler(GET_USER_HOBBIES_NOT_FOUND));
+
+		// 회원 별 취미 데이터가 10개 미만일 경우 예외 처리
+		if (userHobbies.size() < 10) {
+			throw new SurveyExceptionHandler(GET_USER_HOBBIES_LESS);
+		}
 
 		List<UserHobbyResponseDto> getUserHobbyDtoList = userHobbies.stream()
-			.map(UserHobbyResponseDto::userHobbyToDto)
-			.toList();
+				.map(UserHobbyResponseDto::userHobbyToDto)
+				.toList();
 
 		return getUserHobbyDtoList;
 	}

--- a/src/main/java/hobbiedo/survey/presentation/HobbyController.java
+++ b/src/main/java/hobbiedo/survey/presentation/HobbyController.java
@@ -11,6 +11,7 @@ import hobbiedo.global.api.ApiResponse;
 import hobbiedo.global.api.code.status.SuccessStatus;
 import hobbiedo.survey.application.HobbyService;
 import hobbiedo.survey.dto.response.UserHobbyResponseDto;
+import hobbiedo.survey.vo.response.RemainingUserHobbyResponseVo;
 import hobbiedo.survey.vo.response.UserHobbyCardResponseVo;
 import hobbiedo.survey.vo.response.UserHobbyResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,26 +31,39 @@ public class HobbyController {
 	@GetMapping("/hobbies")
 	@Operation(summary = "회원 취미 조회", description = "회원의 취미 리스트를 조회합니다.")
 	public ApiResponse<List<UserHobbyResponseVo>> getUserHobbies(
-		@RequestHeader(name = "Uuid") String uuid) {
+			@RequestHeader(name = "Uuid") String uuid) {
 
 		List<UserHobbyResponseDto> userHobbies = hobbyService.getUserHobbies(uuid);
 
 		return ApiResponse.onSuccess(
-			SuccessStatus.GET_USER_HOBBIES_SUCCESS,
-			UserHobbyResponseVo.userHobbyDtoToVo(userHobbies)
+				SuccessStatus.GET_USER_HOBBIES_SUCCESS,
+				UserHobbyResponseVo.userHobbyDtoToVo(userHobbies)
 		);
 	}
 
 	@GetMapping("/hobby-cards")
 	@Operation(summary = "회원 취미 카드 조회", description = "회원의 취미 카드 리스트를 조회합니다.")
 	public ApiResponse<List<UserHobbyCardResponseVo>> getUserHobbyCards(
-		@RequestHeader(name = "Uuid") String uuid) {
+			@RequestHeader(name = "Uuid") String uuid) {
 
 		List<UserHobbyResponseDto> userHobbies = hobbyService.getUserHobbies(uuid);
 
 		return ApiResponse.onSuccess(
-			SuccessStatus.GET_USER_HOBBY_CARDS_SUCCESS,
-			UserHobbyCardResponseVo.userHobbyDtoToCardVo(userHobbies)
+				SuccessStatus.GET_USER_HOBBY_CARDS_SUCCESS,
+				UserHobbyCardResponseVo.userHobbyDtoToCardVo(userHobbies)
+		);
+	}
+
+	@GetMapping("/remaining-hobbies")
+	@Operation(summary = "나머지 회원 취미 추천", description = "회원의 나머지 취미 id 리스트를 조회합니다. [나머지 취미 소모임 추천용]")
+	public ApiResponse<List<RemainingUserHobbyResponseVo>> getRemainingUserHobbies(
+			@RequestHeader(name = "Uuid") String uuid) {
+
+		List<UserHobbyResponseDto> userHobbies = hobbyService.getUserHobbies(uuid);
+
+		return ApiResponse.onSuccess(
+				SuccessStatus.GET_REMAINING_USER_HOBBIES_SUCCESS,
+				RemainingUserHobbyResponseVo.userHobbyDtoToRemainingVo(userHobbies)
 		);
 	}
 }

--- a/src/main/java/hobbiedo/survey/vo/response/RemainingUserHobbyResponseVo.java
+++ b/src/main/java/hobbiedo/survey/vo/response/RemainingUserHobbyResponseVo.java
@@ -1,0 +1,44 @@
+package hobbiedo.survey.vo.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import hobbiedo.survey.dto.response.UserHobbyResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "저장된 회원의 나머지 취미 정보")
+public class RemainingUserHobbyResponseVo {
+
+	private Long hobbyId;
+	private String hobbyName;
+
+	public RemainingUserHobbyResponseVo(Long hobbyId, String hobbyName) {
+		this.hobbyId = hobbyId;
+		this.hobbyName = hobbyName;
+	}
+
+	public static List<RemainingUserHobbyResponseVo> userHobbyDtoToRemainingVo(
+		List<UserHobbyResponseDto> userHobbyDtoList) {
+
+		List<RemainingUserHobbyResponseVo> getRemainingUserHobbyVoList = new ArrayList<>();
+
+		// 리스트의 크기가 5보다 작은 경우, fromIndex 에는 0이 들어간다.
+		int fromIndex = Math.max(0, userHobbyDtoList.size() - 5);
+
+		// 5번째 요소부터 마지막 요소까지만 가져오기
+		List<UserHobbyResponseDto> subList = userHobbyDtoList.subList(fromIndex, userHobbyDtoList.size());
+
+		for (UserHobbyResponseDto userHobbyDto : subList) {
+			getRemainingUserHobbyVoList.add(new RemainingUserHobbyResponseVo(
+				userHobbyDto.getHobbyId(),
+				userHobbyDto.getHobbyName()
+			));
+		}
+
+		return getRemainingUserHobbyVoList;
+	}
+}

--- a/src/main/java/hobbiedo/survey/vo/response/RemainingUserHobbyResponseVo.java
+++ b/src/main/java/hobbiedo/survey/vo/response/RemainingUserHobbyResponseVo.java
@@ -22,20 +22,17 @@ public class RemainingUserHobbyResponseVo {
 	}
 
 	public static List<RemainingUserHobbyResponseVo> userHobbyDtoToRemainingVo(
-		List<UserHobbyResponseDto> userHobbyDtoList) {
+			List<UserHobbyResponseDto> userHobbyDtoList) {
 
 		List<RemainingUserHobbyResponseVo> getRemainingUserHobbyVoList = new ArrayList<>();
 
-		// 리스트의 크기가 5보다 작은 경우, fromIndex 에는 0이 들어간다.
-		int fromIndex = Math.max(0, userHobbyDtoList.size() - 5);
-
 		// 5번째 요소부터 마지막 요소까지만 가져오기
-		List<UserHobbyResponseDto> subList = userHobbyDtoList.subList(fromIndex, userHobbyDtoList.size());
+		List<UserHobbyResponseDto> subList = userHobbyDtoList.subList(5, userHobbyDtoList.size());
 
 		for (UserHobbyResponseDto userHobbyDto : subList) {
 			getRemainingUserHobbyVoList.add(new RemainingUserHobbyResponseVo(
-				userHobbyDto.getHobbyId(),
-				userHobbyDto.getHobbyName()
+					userHobbyDto.getHobbyId(),
+					userHobbyDto.getHobbyName()
 			));
 		}
 


### PR DESCRIPTION
## 📣 회원 별 취미 나머지 취미 id 리스트 조회 기능 추가
### 📅 날짜 -  2024.06.10

### 🌵Branch
feature/another-users-hobby-id-list  → develop

### 📢 Description
회원 별 취미 중 추천 취미 상위 5개를 제외한 하위 5개 취미 id 를 조회한다

### 💬Issue Number
[#6 ] - 💫[FEAT] 회원 별 취미 추천취미 외 취미 소모임 추천을 위한 취미 id 반환 기능 추가

### 🛠️Type
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
로컬 MySQL 의 임시 데이터를 넣어 테스트를 진행하였고, 하위 5개의 취미 리스트 조회하는 것을 확인하였다