### PR TITLE
[REFACTOR] 회원 별 취미 조회 로직 수정

### DIFF
--- a/src/main/java/hobbiedo/survey/application/HobbyServiceImpl.java
+++ b/src/main/java/hobbiedo/survey/application/HobbyServiceImpl.java
@@ -26,9 +26,10 @@ public class HobbyServiceImpl implements HobbyService {
 	@Override
 	public List<UserHobbyResponseDto> getUserHobbies(String uuid) {
 
-		List<UserHobby> userHobbies = Optional.ofNullable(userHobbyRepository.findByUuid(uuid))
-				.filter(list -> !list.isEmpty())
-				.orElseThrow(() -> new SurveyExceptionHandler(GET_USER_HOBBIES_NOT_FOUND));
+		List<UserHobby> userHobbies = Optional.ofNullable(
+				userHobbyRepository.findByUuidOrderByFitRateDesc(uuid))
+			.filter(list -> !list.isEmpty())
+			.orElseThrow(() -> new SurveyExceptionHandler(GET_USER_HOBBIES_NOT_FOUND));
 
 		// 회원 별 취미 데이터가 10개 미만일 경우 예외 처리
 		if (userHobbies.size() < 10) {
@@ -36,8 +37,8 @@ public class HobbyServiceImpl implements HobbyService {
 		}
 
 		List<UserHobbyResponseDto> getUserHobbyDtoList = userHobbies.stream()
-				.map(UserHobbyResponseDto::userHobbyToDto)
-				.toList();
+			.map(UserHobbyResponseDto::userHobbyToDto)
+			.toList();
 
 		return getUserHobbyDtoList;
 	}

--- a/src/main/java/hobbiedo/survey/infrastructure/UserHobbyRepository.java
+++ b/src/main/java/hobbiedo/survey/infrastructure/UserHobbyRepository.java
@@ -21,4 +21,6 @@ public interface UserHobbyRepository extends JpaRepository<UserHobby, Long> {
 	@Modifying
 	@Query("DELETE FROM UserHobby uh WHERE uh.uuid = :uuid")
 	void deleteByUuid(@Param("uuid") String uuid);
+
+	List<UserHobby> findByUuidOrderByFitRateDesc(String uuid);
 }


### PR DESCRIPTION
## 📣 회원 별 취미 조회 로직 수정
### 📅 날짜 -  2024.07.02
### 🌵Branch
feature/update-user-hobbies-sorting → develop

### 📢 Description
**회원 별 취미 조회 jpa 메서드를 해당 uuid 의 적합도 순으로 조회하게끔 한다**

### 💬Issue Number
[#14 ] - ♻️[REFACTOR] 회원 별 취미 조회 로직 수정 #14

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
Swagger 를 통해 조회가 되는 것을 확인하였다